### PR TITLE
ap - added placeholder pages for ucsbsubject list and create

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -11,6 +11,9 @@ import UCSBDatesIndexPage from "main/pages/UCSBDates/UCSBDatesIndexPage";
 import UCSBDatesCreatePage from "main/pages/UCSBDates/UCSBDatesCreatePage";
 import UCSBDatesEditPage from "main/pages/UCSBDates/UCSBDatesEditPage";
 
+import UCSBSubjectsIndexPage from "main/pages/UCSBSubjects/UCSBSubjectsIndexPage";
+import UCSBSubjectsCreatePage from "main/pages/UCSBSubjects/UCSBSubjectsCreatePage";
+
 
 import StudentsIndexPage from "main/pages/Students/StudentsIndexPage";
 import StudentsCreatePage from "main/pages/Students/StudentsCreatePage";
@@ -41,7 +44,7 @@ function App() {
             </>
           )
         }
-
+        
 
         {
           hasRole(currentUser, "ROLE_USER") && (
@@ -70,6 +73,20 @@ function App() {
             <>
               <Route exact path="/ucsbdates/edit/:id" element={<UCSBDatesEditPage />} />
               <Route exact path="/ucsbdates/create" element={<UCSBDatesCreatePage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_USER") && (
+            <>
+              <Route exact path="/ucsbsubjects/list" element={<UCSBSubjectsIndexPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_ADMIN") && (
+            <>
+              <Route exact path="/ucsbsubjects/create" element={<UCSBSubjectsCreatePage />} />
             </>
           )
         }

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -94,6 +94,21 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
               }
             </Nav>
 
+            <Nav className="mr-auto">
+              {
+                hasRole(currentUser, "ROLE_USER") && (
+                  <NavDropdown title="UCSBSubjects" id="appnavbar-ucsbsubjects-dropdown" data-testid="appnavbar-ucsbsubjects-dropdown" >
+                    <NavDropdown.Item href="/ucsbsubjects/list" data-testid="appnavbar-ucsbsubjects-list">List</NavDropdown.Item>
+                    {
+                      hasRole(currentUser, "ROLE_ADMIN") && (
+                        <NavDropdown.Item href="/ucsbsubjects/create" data-testid="appnavbar-ucsbsubjects-create">Create</NavDropdown.Item>
+                      )
+                    }
+                  </NavDropdown>
+                )
+              }
+            </Nav>
+
             <Nav className="ml-auto">
               {
                 currentUser && currentUser.loggedIn ? (

--- a/frontend/src/main/pages/UCSBSubjects/UCSBSubjectsCreatePage.js
+++ b/frontend/src/main/pages/UCSBSubjects/UCSBSubjectsCreatePage.js
@@ -1,0 +1,14 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function UCSBSubjectsCreatePage() {
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>UCSBSubjects</h1>
+        <p>
+          This is where the create page will go
+        </p>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/UCSBSubjects/UCSBSubjectsIndexPage.js
+++ b/frontend/src/main/pages/UCSBSubjects/UCSBSubjectsIndexPage.js
@@ -1,0 +1,14 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function UCSBSubjectsIndexPage() {
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>UCSBSubjects</h1>
+        <p>
+          This is where the index page will go
+        </p>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/stories/pages/UCSBSubjects/UCSBSubjectsCreatePage.stories.js
+++ b/frontend/src/stories/pages/UCSBSubjects/UCSBSubjectsCreatePage.stories.js
@@ -1,0 +1,17 @@
+
+import React from 'react';
+
+import UCSBSubjectsCreatePage from "main/pages/UCSBSubjects/UCSBSubjectsCreatePage";
+
+export default {
+    title: 'pages/UCSBSubjects/UCSBSubjectsCreatePage',
+    component: UCSBSubjectsCreatePage
+};
+
+const Template = () => <UCSBSubjectsCreatePage />;
+
+export const Default = Template.bind({});
+
+
+
+

--- a/frontend/src/stories/pages/UCSBSubjects/UCSBSubjectsIndexPage.stories.js
+++ b/frontend/src/stories/pages/UCSBSubjects/UCSBSubjectsIndexPage.stories.js
@@ -1,0 +1,17 @@
+
+import React from 'react';
+
+import UCSBSubjectsIndexPage from "main/pages/UCSBSubjects/UCSBSubjectsIndexPage";
+
+export default {
+    title: 'pages/UCSBSubjects/UCSBSubjectsIndexPage',
+    component: UCSBSubjectsIndexPage
+};
+
+const Template = () => <UCSBSubjectsIndexPage />;
+
+export const Default = Template.bind({});
+
+
+
+

--- a/frontend/src/tests/components/Nav/AppNavbar.test.js
+++ b/frontend/src/tests/components/Nav/AppNavbar.test.js
@@ -261,6 +261,54 @@ describe("AppNavbar tests", () => {
 
     });
 
+    test("renders the UCSBSubjects menu correctly for a user", async () => {
+
+        const currentUser = currentUserFixtures.userOnly;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        const {getByTestId  } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByTestId("appnavbar-ucsbsubjects-dropdown")).toBeInTheDocument());
+        const dropdown = getByTestId("appnavbar-ucsbsubjects-dropdown");
+        const aElement = dropdown.querySelector("a");
+        expect(aElement).toBeInTheDocument();
+        aElement?.click();
+        await waitFor( () => expect(getByTestId("appnavbar-ucsbsubjects-list")).toBeInTheDocument() );
+
+    });
+
+    test("renders the UCSBSubjects menu correctly for an admin", async () => {
+
+        const currentUser = currentUserFixtures.adminUser;
+        const systemInfo = systemInfoFixtures.showingBoth;
+
+        const doLogin = jest.fn();
+
+        const {getByTestId  } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AppNavbar currentUser={currentUser} systemInfo={systemInfo} doLogin={doLogin} />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => expect(getByTestId("appnavbar-ucsbsubjects-dropdown")).toBeInTheDocument());
+        const dropdown = getByTestId("appnavbar-ucsbsubjects-dropdown");
+        const aElement = dropdown.querySelector("a");
+        expect(aElement).toBeInTheDocument();
+        aElement?.click();
+        await waitFor( () => expect(getByTestId(/appnavbar-ucsbsubjects-create/)).toBeInTheDocument() );
+
+    });
+
 });
 
 

--- a/frontend/src/tests/pages/UCSBSubjects/UCSBSubjectsCreatePage.test.js
+++ b/frontend/src/tests/pages/UCSBSubjects/UCSBSubjectsCreatePage.test.js
@@ -1,0 +1,56 @@
+import { render, waitFor, fireEvent } from "@testing-library/react";
+import UCSBSubjectsCreatePage from "main/pages/UCSBSubjects/UCSBSubjectsCreatePage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
+
+describe("UCSBSubjectsCreatePage tests", () => {
+
+    const axiosMock =new AxiosMockAdapter(axios);
+
+    beforeEach(() => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    });
+
+    test("renders without crashing", () => {
+        const queryClient = new QueryClient();
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBSubjectsCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+
+});
+
+

--- a/frontend/src/tests/pages/UCSBSubjects/UCSBSubjectsCreatePage.test.js
+++ b/frontend/src/tests/pages/UCSBSubjects/UCSBSubjectsCreatePage.test.js
@@ -1,4 +1,4 @@
-import { render, waitFor, fireEvent } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import UCSBSubjectsCreatePage from "main/pages/UCSBSubjects/UCSBSubjectsCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
@@ -8,39 +8,14 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
-const mockToast = jest.fn();
-jest.mock('react-toastify', () => {
-    const originalModule = jest.requireActual('react-toastify');
-    return {
-        __esModule: true,
-        ...originalModule,
-        toast: (x) => mockToast(x)
-    };
-});
-
-const mockNavigate = jest.fn();
-jest.mock('react-router-dom', () => {
-    const originalModule = jest.requireActual('react-router-dom');
-    return {
-        __esModule: true,
-        ...originalModule,
-        Navigate: (x) => { mockNavigate(x); return null; }
-    };
-});
-
 describe("UCSBSubjectsCreatePage tests", () => {
 
     const axiosMock =new AxiosMockAdapter(axios);
+    axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
 
-    beforeEach(() => {
-        axiosMock.reset();
-        axiosMock.resetHistory();
-        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    });
-
-    test("renders without crashing", () => {
-        const queryClient = new QueryClient();
+    const queryClient = new QueryClient();
+    test("renders without crashing for admin user", () => {
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>

--- a/frontend/src/tests/pages/UCSBSubjects/UCSBSubjectsIndexPage.test.js
+++ b/frontend/src/tests/pages/UCSBSubjects/UCSBSubjectsIndexPage.test.js
@@ -1,4 +1,4 @@
-import { fireEvent, render, waitFor } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import UCSBSubjectsIndexPage from "main/pages/UCSBSubjects/UCSBSubjectsIndexPage";
@@ -8,58 +8,15 @@ import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
-import mockConsole from "jest-mock-console";
-
-
-const mockToast = jest.fn();
-jest.mock('react-toastify', () => {
-    const originalModule = jest.requireActual('react-toastify');
-    return {
-        __esModule: true,
-        ...originalModule,
-        toast: (x) => mockToast(x)
-    };
-});
 
 describe("UCSBSubjectsIndexPage tests", () => {
 
     const axiosMock =new AxiosMockAdapter(axios);
+    axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
 
-    const testId = "UCSBSubjectsTable";
-
-    const setupUserOnly = () => {
-        axiosMock.reset();
-        axiosMock.resetHistory();
-        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    };
-
-    const setupAdminUser = () => {
-        axiosMock.reset();
-        axiosMock.resetHistory();
-        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    };
-
-    test("renders without crashing for regular user", () => {
-        setupUserOnly();
-        const queryClient = new QueryClient();
-        axiosMock.onGet("/api/ucsbsubjects/all").reply(200, []);
-
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <UCSBSubjectsIndexPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
-
-
-    });
-
-    test("renders without crashing for admin user", () => {
-        setupAdminUser();
-        const queryClient = new QueryClient();
+    const queryClient = new QueryClient();
+    test("renders without crashing", () => {
         axiosMock.onGet("/api/ucsbsubjects/all").reply(200, []);
 
         render(

--- a/frontend/src/tests/pages/UCSBSubjects/UCSBSubjectsIndexPage.test.js
+++ b/frontend/src/tests/pages/UCSBSubjects/UCSBSubjectsIndexPage.test.js
@@ -1,0 +1,79 @@
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+import UCSBSubjectsIndexPage from "main/pages/UCSBSubjects/UCSBSubjectsIndexPage";
+
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
+
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("UCSBSubjectsIndexPage tests", () => {
+
+    const axiosMock =new AxiosMockAdapter(axios);
+
+    const testId = "UCSBSubjectsTable";
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    test("renders without crashing for regular user", () => {
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/ucsbsubjects/all").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBSubjectsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+
+    });
+
+    test("renders without crashing for admin user", () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/ucsbsubjects/all").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBSubjectsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+
+    });
+
+
+});
+
+

--- a/frontend/src/tests/pages/UCSBSubjects/UCSBSubjectsIndexPage.test.js
+++ b/frontend/src/tests/pages/UCSBSubjects/UCSBSubjectsIndexPage.test.js
@@ -17,8 +17,6 @@ describe("UCSBSubjectsIndexPage tests", () => {
 
     const queryClient = new QueryClient();
     test("renders without crashing", () => {
-        axiosMock.onGet("/api/ucsbsubjects/all").reply(200, []);
-
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>


### PR DESCRIPTION
# Overview

In this pull request I added placeholder pages for UCSBSubjects list and create. I completed all the sub tasks and localhost images are below. The branch runs on heroku and the functionality remains the same. I did not take screenshots for redundancy.

UCSBSubjects not appearing on navbar per task specification
![Screenshot 2022-02-16 134325](https://user-images.githubusercontent.com/56096744/154363734-cb6c57bd-f476-4a0a-8349-4ad461763c99.png)

UCSBSubject dropdown appearing on navbar when logged in, create appearing when admin
![Screenshot 2022-02-16 134313](https://user-images.githubusercontent.com/56096744/154363872-0cb8719c-18d5-4cbc-a5a8-44ce2a218516.png)

Create and List pages (Screenshots taken before ucsbsubjects added to navbar)
![Screenshot 2022-02-16 133836](https://user-images.githubusercontent.com/56096744/154364055-8f9faeed-1cd4-4f82-befe-f772343a621e.png)
![Screenshot 2022-02-16 133818](https://user-images.githubusercontent.com/56096744/154364060-14438d23-6f91-463b-a64d-191559671f6a.png)

Story book pages
![Screenshot 2022-02-16 135653](https://user-images.githubusercontent.com/56096744/154365531-011360ed-4fe5-48ad-8147-d7fd653ee2bb.png)


