### PR TITLE
ap - added list page for ucsbsubjects

### DIFF
--- a/frontend/src/main/components/UCSBSubjects/UCSBSubjectForm.js
+++ b/frontend/src/main/components/UCSBSubjects/UCSBSubjectForm.js
@@ -114,12 +114,12 @@ function UCSBSubjectForm({ initialUCSBSubject, submitAction, buttonLabel="Create
                     data-testid="UCSBSubjectForm-inactive"
                     id="inactive"
                     type="boolean"
-                    isInvalid={Boolean(errors.invalid)}
-                    {...register("invalid", { required: true, pattern: bool_regex })}
+                    isInvalid={Boolean(errors.inactive)}
+                    {...register("inactive", { required: true, pattern: bool_regex })}
                 />
                 <Form.Control.Feedback type="invalid">
-                    {errors.invalid && 'Inactive is required. '}
-                    {errors.invalid?.type === 'pattern' && 'Inactive must be a boolean'}
+                    {errors.inactive && 'Inactive is required. '}
+                    {errors.inactive?.type === 'pattern' && 'Inactive must be a boolean'}
                 </Form.Control.Feedback>
             </Form.Group>
             

--- a/frontend/src/main/pages/UCSBSubjects/UCSBSubjectsIndexPage.js
+++ b/frontend/src/main/pages/UCSBSubjects/UCSBSubjectsIndexPage.js
@@ -1,13 +1,27 @@
+import React from 'react'
+import { useBackend } from 'main/utils/useBackend';
+
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import UCSBSubjectsTable from 'main/components/UCSBSubjects/UCSBSubjectsTable';
+import { useCurrentUser } from 'main/utils/currentUser'
 
 export default function UCSBSubjectsIndexPage() {
+
+  const currentUser = useCurrentUser();
+
+  const { data: subjects, error: _error, status: _status } =
+    useBackend(
+      // Stryker disable next-line all : don't test internal caching of React Query
+      ["/api/ucsbsubjects/all"],
+      { method: "GET", url: "/api/ucsbsubjects/all" },
+      []
+    );
+
   return (
     <BasicLayout>
       <div className="pt-2">
         <h1>UCSBSubjects</h1>
-        <p>
-          This is where the index page will go
-        </p>
+        <UCSBSubjectsTable subjects={subjects} currentUser={currentUser} />
       </div>
     </BasicLayout>
   )

--- a/frontend/src/tests/pages/UCSBSubjects/UCSBSubjectsIndexPage.test.js
+++ b/frontend/src/tests/pages/UCSBSubjects/UCSBSubjectsIndexPage.test.js
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 import UCSBSubjectsIndexPage from "main/pages/UCSBSubjects/UCSBSubjectsIndexPage";
@@ -6,17 +6,47 @@ import UCSBSubjectsIndexPage from "main/pages/UCSBSubjects/UCSBSubjectsIndexPage
 
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { ucsbSubjectsFixtures } from "fixtures/ucsbSubjectsFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
+import mockConsole from "jest-mock-console";
+
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
 
 describe("UCSBSubjectsIndexPage tests", () => {
 
     const axiosMock =new AxiosMockAdapter(axios);
-    axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
 
-    const queryClient = new QueryClient();
-    test("renders without crashing", () => {
+    const testId = "UCSBSubjectsTable";
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const setupAdminUser = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    test("renders without crashing for regular user", () => {
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/ucsbsubjects/all").reply(200, []);
+
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -28,7 +58,81 @@ describe("UCSBSubjectsIndexPage tests", () => {
 
     });
 
+    test("renders without crashing for admin user", () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/ucsbsubjects/all").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBSubjectsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+
+    });
+
+    test("renders three subjects without crashing for regular user", async () => {
+        setupUserOnly();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/ucsbsubjects/all").reply(200, ucsbSubjectsFixtures.threeSubjects);
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBSubjectsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-subjectCode`)).toHaveTextContent("test1"); });
+        expect(getByTestId(`${testId}-cell-row-1-col-subjectCode`)).toHaveTextContent("test2");
+        expect(getByTestId(`${testId}-cell-row-2-col-subjectCode`)).toHaveTextContent("test3");
+    });
+
+    test("renders three subjects without crashing for admin user", async () => {
+        setupAdminUser();
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/ucsbsubjects/all").reply(200, ucsbSubjectsFixtures.threeSubjects);
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBSubjectsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(getByTestId(`${testId}-cell-row-0-col-subjectCode`)).toHaveTextContent("test1"); });
+        expect(getByTestId(`${testId}-cell-row-1-col-subjectCode`)).toHaveTextContent("test2");
+        expect(getByTestId(`${testId}-cell-row-2-col-subjectCode`)).toHaveTextContent("test3");
+    });
+
+    test("renders empty table when backend unavailable, user only", async () => {
+        setupUserOnly();
+
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/ucsbsubjects/all").timeout();
+
+        const restoreConsole = mockConsole();
+
+        const { queryByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <UCSBSubjectsIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => { expect(axiosMock.history.get.length).toBeGreaterThanOrEqual(1); });
+
+        const errorMessage = console.error.mock.calls[0][0];
+        expect(errorMessage).toMatch("Error communicating with backend via GET on /api/ucsbsubjects/all");
+        restoreConsole();
+
+        expect(queryByTestId(`${testId}-cell-row-0-col-id`)).not.toBeInTheDocument();
+    });
 
 });
-
-

--- a/src/main/java/edu/ucsb/cs156/example/controllers/UCSBSubjectController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/UCSBSubjectController.java
@@ -31,7 +31,7 @@ import javax.validation.Valid;
 import java.util.Optional;
 
 @Api(description = "UCSBSubjects")
-@RequestMapping("/api/ucsbSubjects")
+@RequestMapping("/api/ucsbsubjects")
 @RestController
 @Slf4j
 public class UCSBSubjectController extends ApiController {

--- a/src/test/java/edu/ucsb/cs156/example/controllers/UCSBSubjectControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/example/controllers/UCSBSubjectControllerTests.java
@@ -44,14 +44,14 @@ public class UCSBSubjectControllerTests extends ControllerTestCase {
 
     @Test
     public void api_ucsbSubject_all__logged_out__returns_403() throws Exception {
-        mockMvc.perform(get("/api/ucsbSubjects/all"))
+        mockMvc.perform(get("/api/ucsbsubjects/all"))
                 .andExpect(status().is(403));
     }
 
     @WithMockUser(roles = { "USER" })
     @Test
     public void api_ucsbSubject_all__user_logged_in__returns_200() throws Exception {
-        mockMvc.perform(get("/api/ucsbSubjects/all"))
+        mockMvc.perform(get("/api/ucsbsubjects/all"))
                 .andExpect(status().isOk());
     }
 
@@ -59,14 +59,14 @@ public class UCSBSubjectControllerTests extends ControllerTestCase {
 
     @Test
     public void api_ucsbSubject_post__logged_out__returns_403() throws Exception {
-        mockMvc.perform(post("/api/ucsbSubjects/post"))
+        mockMvc.perform(post("/api/ucsbsubjects/post"))
                 .andExpect(status().is(403));
     }
 
     @WithMockUser(roles = { "USER" })
     @Test
     public void api_ucsbSubject_post__logged_out__returns_200() throws Exception {
-        mockMvc.perform(get("/api/ucsbSubjects/all"))
+        mockMvc.perform(get("/api/ucsbsubjects/all"))
                 .andExpect(status().isOk());
     }
 
@@ -83,7 +83,7 @@ public class UCSBSubjectControllerTests extends ControllerTestCase {
         when(ucsbSubjectRepository.findAll()).thenReturn(expectedUCSBSubjects);
 
         // act
-        MvcResult response = mockMvc.perform(get("/api/ucsbSubjects/all"))
+        MvcResult response = mockMvc.perform(get("/api/ucsbsubjects/all"))
                 .andExpect(status().isOk()).andReturn();
 
         // assert
@@ -113,7 +113,7 @@ public class UCSBSubjectControllerTests extends ControllerTestCase {
 
         // act
         MvcResult response = mockMvc.perform(
-                post("/api/ucsbSubjects/post?subjectCode=Test Code&subjectTranslation=Test Translation&deptCode=Test DeptCode&collegeCode=Test CollegeCode&relatedDeptCode=Test RelatedDeptCode&inactive=true")
+                post("/api/ucsbsubjects/post?subjectCode=Test Code&subjectTranslation=Test Translation&deptCode=Test DeptCode&collegeCode=Test CollegeCode&relatedDeptCode=Test RelatedDeptCode&inactive=true")
                         .with(csrf()))
                 .andExpect(status().isOk()).andReturn();
 
@@ -137,7 +137,7 @@ public class UCSBSubjectControllerTests extends ControllerTestCase {
         when(ucsbSubjectRepository.findById(eq(7L))).thenReturn(Optional.of(ucsbSubject7));
 
         // act
-        MvcResult response = mockMvc.perform(get("/api/ucsbSubjects?id=7"))
+        MvcResult response = mockMvc.perform(get("/api/ucsbsubjects?id=7"))
                 .andExpect(status().isOk()).andReturn();
 
         // assert
@@ -159,7 +159,7 @@ public class UCSBSubjectControllerTests extends ControllerTestCase {
         when(ucsbSubjectRepository.findById(eq(7L))).thenReturn(Optional.empty());
 
         // act
-        MvcResult response = mockMvc.perform(get("/api/ucsbSubjects?id=7"))
+        MvcResult response = mockMvc.perform(get("/api/ucsbsubjects?id=7"))
                 .andExpect(status().isBadRequest()).andReturn();
 
         // assert
@@ -192,7 +192,7 @@ public class UCSBSubjectControllerTests extends ControllerTestCase {
         when(ucsbSubjectRepository.findById(eq(7L))).thenReturn(Optional.of(ucsbSubject1));
         // act
         MvcResult response = mockMvc.perform(
-                put("/api/ucsbSubjects?id=7")
+                put("/api/ucsbsubjects?id=7")
                         .contentType(MediaType.APPLICATION_JSON)
                         .characterEncoding("utf-8")
                         .content(requestBody)
@@ -218,7 +218,7 @@ public class UCSBSubjectControllerTests extends ControllerTestCase {
 
         // act
         MvcResult response = mockMvc.perform(
-                put("/api/ucsbSubjects?id=7")
+                put("/api/ucsbsubjects?id=7")
                         .contentType(MediaType.APPLICATION_JSON)
                         .characterEncoding("utf-8")
                         .content(requestBody)
@@ -242,7 +242,7 @@ public class UCSBSubjectControllerTests extends ControllerTestCase {
 
         // act
         MvcResult response = mockMvc.perform(
-                delete("/api/ucsbSubjects?id=7")
+                delete("/api/ucsbsubjects?id=7")
                         .with(csrf()))
                 .andExpect(status().isOk()).andReturn();
 
@@ -261,7 +261,7 @@ public class UCSBSubjectControllerTests extends ControllerTestCase {
 
         // act
         MvcResult response = mockMvc.perform(
-                delete("/api/ucsbSubjects?id=7")
+                delete("/api/ucsbsubjects?id=7")
                         .with(csrf()))
                 .andExpect(status().isBadRequest()).andReturn();
 


### PR DESCRIPTION
# Overview

In this pull request, I added the list page for ucsbsubjects and replaced the placeholder page that was already there. I made some typo fixes to the ucsbsubjectform and made changes to the backend ucsbsubject controller to make the naming consistent with what were working on now.

Screenshot of list page on localhost
![Screenshot 2022-02-23 104251](https://user-images.githubusercontent.com/56096744/155388393-7cbe7f85-a110-4412-8c40-953ab791ba70.jpg)

Test coverage for ucsbsubjectindex

![Screenshot 2022-02-23 104348](https://user-images.githubusercontent.com/56096744/155388568-3bea0691-0fa6-4177-894c-e8f529b0cd5d.jpg)

Did mutation testing through github draft pull request since my computer slows down a lot when doing npx stryker run on my console.
