### PR TITLE
rj - implemented form for Earthquake and tests

### DIFF
--- a/.github/workflows/02-frontend-03-mutation-testing.yml
+++ b/.github/workflows/02-frontend-03-mutation-testing.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 50
 
     strategy:
       matrix:

--- a/frontend/src/main/components/Earthquakes/EarthquakeForm.js
+++ b/frontend/src/main/components/Earthquakes/EarthquakeForm.js
@@ -1,0 +1,83 @@
+import React, {useState} from 'react'
+import { Button, Form } from 'react-bootstrap';
+import { useForm } from 'react-hook-form'
+import { useNavigate } from 'react-router-dom'
+
+
+function EarthquakeForm({ initialEarthquake, submitAction, buttonLabel="Retrieve" }) {
+
+    // Stryker disable all
+    const {
+        register,
+        formState: { errors },
+        handleSubmit,
+    } = useForm(
+        { defaultValues: initialEarthquake || {}, }
+    );
+    // Stryker enable all
+
+    const navigate = useNavigate();
+
+    // For explanation, see: https://stackoverflow.com/questions/3143070/javascript-regex-iso-datetime
+    // Note that even this complex regex may still need some tweaks
+
+    // Stryker disable next-line Regex
+    //const isodate_regex = /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d)/i;
+
+    // Stryker disable next-line all
+    //const yyyyq_regex = /((19)|(20))\d{2}[1-4]/i; // Accepts from 1900-2099 followed by 1-4.  Close enough.
+
+    return (
+
+        <Form onSubmit={handleSubmit(submitAction)}>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="distance">Distance</Form.Label>
+                <Form.Control
+                    data-testid="EarthquakeForm-distance"
+                    id="distance"
+                    type="text"
+                    isInvalid={Boolean(errors.distance)}
+                    {...register("distance", { required: "Distance is required." })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.distance?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="magnitude">Minimum Magnitude</Form.Label>
+                <Form.Control
+                    data-testid="EarthquakeForm-magnitude"
+                    id="magnitude"
+                    type="text"
+                    isInvalid={Boolean(errors.magnitude)}
+                    {...register("magnitude", {
+                        required: "Minimum Magnitude is required."
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.magnitude?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Button
+                type="submit"
+                data-testid="EarthquakeForm-submit"
+            >
+                {buttonLabel}
+            </Button>
+            <Button
+                variant="Secondary"
+                onClick={() => navigate(-1)}
+                data-testid="EarthquakeForm-cancel"
+            >
+                Cancel
+            </Button>
+
+        </Form>
+
+    )
+}
+
+export default EarthquakeForm;

--- a/frontend/src/main/components/Earthquakes/EarthquakeForm.js
+++ b/frontend/src/main/components/Earthquakes/EarthquakeForm.js
@@ -46,18 +46,18 @@ function EarthquakeForm({ initialEarthquake, submitAction, buttonLabel="Retrieve
             </Form.Group>
 
             <Form.Group className="mb-3" >
-                <Form.Label htmlFor="magnitude">Minimum Magnitude</Form.Label>
+                <Form.Label htmlFor="mag">Minimum Magnitude</Form.Label>
                 <Form.Control
-                    data-testid="EarthquakeForm-magnitude"
-                    id="magnitude"
+                    data-testid="EarthquakeForm-mag"
+                    id="mag"
                     type="text"
-                    isInvalid={Boolean(errors.magnitude)}
-                    {...register("magnitude", {
+                    isInvalid={Boolean(errors.mag)}
+                    {...register("mag", {
                         required: "Minimum Magnitude is required."
                     })}
                 />
                 <Form.Control.Feedback type="invalid">
-                    {errors.magnitude?.message}
+                    {errors.mag?.message}
                 </Form.Control.Feedback>
             </Form.Group>
 

--- a/frontend/src/stories/components/Earthquakes/EarthquakeForm.stories.js
+++ b/frontend/src/stories/components/Earthquakes/EarthquakeForm.stories.js
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import EarthquakeForm from "main/components/Earthquakes/EarthquakeForm"
+import { earthquakesFixtures } from 'fixtures/earthquakesFixtures';
+
+export default {
+    title: 'components/Earthquakes/EarthquakeForm',
+    component: EarthquakeForm
+};
+
+
+const Template = (args) => {
+    return (
+        <EarthquakeForm {...args} />
+    )
+};
+
+export const Default = Template.bind({});
+
+Default.args = {
+    submitText: "Create",
+    submitAction: () => { console.log("Submit was clicked"); }
+};
+
+export const Show = Template.bind({});
+
+Show.args = {
+    earthquake: earthquakesFixtures.oneEarthquake,
+    submitText: "",
+    submitAction: () => { }
+};

--- a/frontend/src/tests/components/Earthquakes/EarthquakeForm.test.js
+++ b/frontend/src/tests/components/Earthquakes/EarthquakeForm.test.js
@@ -32,9 +32,9 @@ describe("EarthquakeForm tests", () => {
                 <EarthquakeForm initialEarthquake={earthquakesFixtures.oneEarthquake} />
             </Router>
         );
-        await waitFor(() => expect(getByTestId(/EarthquakeForm-magnitude/)).toBeInTheDocument());
+        await waitFor(() => expect(getByTestId(/EarthquakeForm-mag/)).toBeInTheDocument());
         expect(getByText(/Minimum Magnitude/)).toBeInTheDocument();
-        expect(getByTestId(/EarthquakeForm-magnitude/)).toHaveValue("3.86");
+        expect(getByTestId(/EarthquakeForm-mag/)).toHaveValue("3.86");
     });
 
 /*
@@ -88,11 +88,11 @@ describe("EarthquakeForm tests", () => {
         await waitFor(() => expect(getByTestId("EarthquakeForm-distance")).toBeInTheDocument());
 
         const distanceField = getByTestId("EarthquakeForm-distance");
-        const magnitudeField = getByTestId("EarthquakeForm-magnitude");
+        const magField = getByTestId("EarthquakeForm-mag");
         const submitButton = getByTestId("EarthquakeForm-submit");
 
         fireEvent.change(distanceField, { target: { value: '1.1' } });
-        fireEvent.change(magnitudeField, { target: { value: '2.2' } });
+        fireEvent.change(magField, { target: { value: '2.2' } });
         fireEvent.click(submitButton);
 
         await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());

--- a/frontend/src/tests/components/Earthquakes/EarthquakeForm.test.js
+++ b/frontend/src/tests/components/Earthquakes/EarthquakeForm.test.js
@@ -27,9 +27,11 @@ describe("EarthquakeForm tests", () => {
 
     test("renders correctly when passing in a Earthquake ", async () => {
 
+        var eqQuery = {"distance":"3", "mag":"3.86"};
+
         const { getByText, getByTestId } = render(
             <Router  >
-                <EarthquakeForm initialEarthquake={earthquakesFixtures.oneEarthquake} />
+                <EarthquakeForm initialEarthquake={eqQuery} />
             </Router>
         );
         await waitFor(() => expect(getByTestId(/EarthquakeForm-mag/)).toBeInTheDocument());

--- a/frontend/src/tests/components/Earthquakes/EarthquakeForm.test.js
+++ b/frontend/src/tests/components/Earthquakes/EarthquakeForm.test.js
@@ -34,7 +34,7 @@ describe("EarthquakeForm tests", () => {
         );
         await waitFor(() => expect(getByTestId(/EarthquakeForm-magnitude/)).toBeInTheDocument());
         expect(getByText(/Minimum Magnitude/)).toBeInTheDocument();
-        expect(getByTestId(/EarthquakeForm-magnitude/)).toHaveValue("2.16");
+        expect(getByTestId(/EarthquakeForm-magnitude/)).toHaveValue("3.86");
     });
 
 /*

--- a/frontend/src/tests/components/Earthquakes/EarthquakeForm.test.js
+++ b/frontend/src/tests/components/Earthquakes/EarthquakeForm.test.js
@@ -1,0 +1,121 @@
+import { render, waitFor, fireEvent } from "@testing-library/react";
+import EarthquakeForm from "main/components/Earthquakes/EarthquakeForm";
+import { earthquakesFixtures } from "fixtures/earthquakesFixtures";
+import { BrowserRouter as Router } from "react-router-dom";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+
+describe("EarthquakeForm tests", () => {
+
+    test("renders correctly ", async () => {
+
+        const { getByText } = render(
+            <Router  >
+                <EarthquakeForm />
+            </Router>
+        );
+        await waitFor(() => expect(getByText(/Distance/)).toBeInTheDocument());
+        await waitFor(() => expect(getByText(/Retrieve/)).toBeInTheDocument());
+    });
+
+
+    test("renders correctly when passing in a Earthquake ", async () => {
+
+        const { getByText, getByTestId } = render(
+            <Router  >
+                <EarthquakeForm initialEarthquake={earthquakesFixtures.oneEarthquake} />
+            </Router>
+        );
+        await waitFor(() => expect(getByTestId(/EarthquakeForm-magnitude/)).toBeInTheDocument());
+        expect(getByText(/Minimum Magnitude/)).toBeInTheDocument();
+        expect(getByTestId(/EarthquakeForm-magnitude/)).toHaveValue("2.16");
+    });
+
+/*
+    test("Correct Error messsages on bad input", async () => {
+
+        const { getByTestId, getByText } = render(
+            <Router  >
+                <UCSBDateForm />
+            </Router>
+        );
+        await waitFor(() => expect(getByTestId("UCSBDateForm-quarterYYYYQ")).toBeInTheDocument());
+        const quarterYYYYQField = getByTestId("UCSBDateForm-quarterYYYYQ");
+        const localDateTimeField = getByTestId("UCSBDateForm-localDateTime");
+        const submitButton = getByTestId("UCSBDateForm-submit");
+
+        fireEvent.change(quarterYYYYQField, { target: { value: 'bad-input' } });
+        fireEvent.change(localDateTimeField, { target: { value: 'bad-input' } });
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(getByText(/QuarterYYYYQ must be in the format YYYYQ/)).toBeInTheDocument());
+        expect(getByText(/localDateTime must be in ISO format/)).toBeInTheDocument();
+    });
+*/
+    test("Correct Error messsages on missing input", async () => {
+
+        const { getByTestId, getByText } = render(
+            <Router  >
+                <EarthquakeForm />
+            </Router>
+        );
+        await waitFor(() => expect(getByTestId("EarthquakeForm-submit")).toBeInTheDocument());
+        const submitButton = getByTestId("EarthquakeForm-submit");
+
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(getByText(/Distance is required./)).toBeInTheDocument());
+        expect(getByText(/Minimum Magnitude is required./)).toBeInTheDocument();
+
+    });
+
+    test("No Error messsages on good input", async () => {
+
+        const mockSubmitAction = jest.fn();
+
+
+        const { getByTestId, queryByText } = render(
+            <Router  >
+                <EarthquakeForm submitAction={mockSubmitAction} />
+            </Router>
+        );
+        await waitFor(() => expect(getByTestId("EarthquakeForm-distance")).toBeInTheDocument());
+
+        const distanceField = getByTestId("EarthquakeForm-distance");
+        const magnitudeField = getByTestId("EarthquakeForm-magnitude");
+        const submitButton = getByTestId("EarthquakeForm-submit");
+
+        fireEvent.change(distanceField, { target: { value: '1.1' } });
+        fireEvent.change(magnitudeField, { target: { value: '2.2' } });
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
+
+    });
+
+
+    test("Test that navigate(-1) is called when Cancel is clicked", async () => {
+
+        const { getByTestId } = render(
+            <Router  >
+                <EarthquakeForm />
+            </Router>
+        );
+        await waitFor(() => expect(getByTestId("EarthquakeForm-cancel")).toBeInTheDocument());
+        const cancelButton = getByTestId("EarthquakeForm-cancel");
+
+        fireEvent.click(cancelButton);
+
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+
+    });
+
+});
+
+


### PR DESCRIPTION
# Overview

Implemented retrieve form for Earthquakes: has distance field, magnitude field, submit button, cancel button.

100% on npx stryker
![image](https://user-images.githubusercontent.com/56047961/155919230-09dcb272-7863-42b0-9089-01e2daf3d8eb.png)

100% on npm run coverage
![image](https://user-images.githubusercontent.com/56047961/155919370-cc5d609c-6746-43b6-939e-726d41ab4c30.png)

