### PR TITLE
rj earthquake retrieve form, retrieve page, and tests

### DIFF
--- a/.github/workflows/02-frontend-03-mutation-testing.yml
+++ b/.github/workflows/02-frontend-03-mutation-testing.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 50
+    timeout-minutes: 80
 
     strategy:
       matrix:

--- a/.github/workflows/02-frontend-03-mutation-testing.yml
+++ b/.github/workflows/02-frontend-03-mutation-testing.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    timeout-minutes: 50
 
     strategy:
       matrix:

--- a/frontend/src/main/components/Earthquakes/EarthquakeForm.js
+++ b/frontend/src/main/components/Earthquakes/EarthquakeForm.js
@@ -4,7 +4,7 @@ import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom'
 
 
-function EarthquakeForm({ initialEarthquake, submitAction, buttonLabel="Retrieve1" }) {
+function EarthquakeForm({ initialEarthquake, submitAction, buttonLabel="Retrieve" }) {
 
     // Stryker disable all
     const {

--- a/frontend/src/main/components/Earthquakes/EarthquakeForm.js
+++ b/frontend/src/main/components/Earthquakes/EarthquakeForm.js
@@ -30,7 +30,6 @@ function EarthquakeForm({ initialEarthquake, submitAction, buttonLabel="Retrieve
     return (
 
         <Form onSubmit={handleSubmit(submitAction)}>
-            {initialEarthquake}
             <Form.Group className="mb-3" >
                 <Form.Label htmlFor="distance">Distance</Form.Label>
                 <Form.Control
@@ -51,13 +50,13 @@ function EarthquakeForm({ initialEarthquake, submitAction, buttonLabel="Retrieve
                     data-testid="EarthquakeForm-mag"
                     id="minMag"
                     type="text"
-                    isInvalid={Boolean(errors.mag)}
+                    isInvalid={Boolean(errors.minMag)}
                     {...register("minMag", {
                         required: "Minimum Magnitude is required."
                     })}
                 />
                 <Form.Control.Feedback type="invalid">
-                    {errors.mag?.message}
+                    {errors.minMag?.message}
                 </Form.Control.Feedback>
             </Form.Group>
 

--- a/frontend/src/main/components/Earthquakes/EarthquakeForm.js
+++ b/frontend/src/main/components/Earthquakes/EarthquakeForm.js
@@ -62,7 +62,7 @@ function EarthquakeForm({ initialEarthquake, submitAction, buttonLabel="Retrieve
             </Form.Group>
 
             <Button
-                type="submit"
+                type="submit" //potential
                 data-testid="EarthquakeForm-submit"
             >
                 {buttonLabel}

--- a/frontend/src/main/components/Earthquakes/EarthquakeForm.js
+++ b/frontend/src/main/components/Earthquakes/EarthquakeForm.js
@@ -1,0 +1,83 @@
+import React, {useState} from 'react'
+import { Button, Form } from 'react-bootstrap';
+import { useForm } from 'react-hook-form'
+import { useNavigate } from 'react-router-dom'
+
+
+function EarthquakeForm({ initialEarthquake, submitAction, buttonLabel="Retrieve" }) {
+
+    // Stryker disable all
+    const {
+        register,
+        formState: { errors },
+        handleSubmit,
+    } = useForm(
+        { defaultValues: initialEarthquake || {}, }
+    );
+    // Stryker enable all
+
+    const navigate = useNavigate();
+
+    // For explanation, see: https://stackoverflow.com/questions/3143070/javascript-regex-iso-datetime
+    // Note that even this complex regex may still need some tweaks
+
+    // Stryker disable next-line Regex
+    //const isodate_regex = /(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d\.\d+)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d:[0-5]\d)|(\d{4}-[01]\d-[0-3]\dT[0-2]\d:[0-5]\d)/i;
+
+    // Stryker disable next-line all
+    //const yyyyq_regex = /((19)|(20))\d{2}[1-4]/i; // Accepts from 1900-2099 followed by 1-4.  Close enough.
+
+    return (
+
+        <Form onSubmit={handleSubmit(submitAction)}>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="distance">Distance</Form.Label>
+                <Form.Control
+                    data-testid="EarthquakeForm-distance"
+                    id="distance"
+                    type="text"
+                    isInvalid={Boolean(errors.distance)}
+                    {...register("distance", { required: "Distance is required." })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.distance?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Form.Group className="mb-3" >
+                <Form.Label htmlFor="magnitude">Minimum Magnitude</Form.Label>
+                <Form.Control
+                    data-testid="EarthquakeForm-magnitude"
+                    id="magnitude"
+                    type="text"
+                    isInvalid={Boolean(errors.magnitude)}
+                    {...register("magnitude", {
+                        required: "Minimum Magnitude is required."
+                    })}
+                />
+                <Form.Control.Feedback type="invalid">
+                    {errors.magnitude?.message}
+                </Form.Control.Feedback>
+            </Form.Group>
+
+            <Button
+                type="submit"
+                data-testid="EarthquakeForm-submit"
+            >
+                {buttonLabel}
+            </Button>
+            <Button
+                variant="Secondary"
+                onClick={() => navigate(-1)}
+                data-testid="EarthquakeForm-cancel"
+            >
+                Cancel
+            </Button>
+
+        </Form>
+
+    )
+}
+
+export default EarthquakeForm;

--- a/frontend/src/main/components/Earthquakes/EarthquakeForm.js
+++ b/frontend/src/main/components/Earthquakes/EarthquakeForm.js
@@ -4,7 +4,7 @@ import { useForm } from 'react-hook-form'
 import { useNavigate } from 'react-router-dom'
 
 
-function EarthquakeForm({ initialEarthquake, submitAction, buttonLabel="Retrieve" }) {
+function EarthquakeForm({ initialEarthquake, submitAction, buttonLabel="Retrieve1" }) {
 
     // Stryker disable all
     const {

--- a/frontend/src/main/components/Earthquakes/EarthquakeForm.js
+++ b/frontend/src/main/components/Earthquakes/EarthquakeForm.js
@@ -46,18 +46,18 @@ function EarthquakeForm({ initialEarthquake, submitAction, buttonLabel="Retrieve
             </Form.Group>
 
             <Form.Group className="mb-3" >
-                <Form.Label htmlFor="magnitude">Minimum Magnitude</Form.Label>
+                <Form.Label htmlFor="mag">Minimum Magnitude</Form.Label>
                 <Form.Control
-                    data-testid="EarthquakeForm-magnitude"
-                    id="magnitude"
+                    data-testid="EarthquakeForm-mag"
+                    id="mag"
                     type="text"
-                    isInvalid={Boolean(errors.magnitude)}
-                    {...register("magnitude", {
+                    isInvalid={Boolean(errors.mag)}
+                    {...register("mag", {
                         required: "Minimum Magnitude is required."
                     })}
                 />
                 <Form.Control.Feedback type="invalid">
-                    {errors.magnitude?.message}
+                    {errors.mag?.message}
                 </Form.Control.Feedback>
             </Form.Group>
 

--- a/frontend/src/main/components/Earthquakes/EarthquakeForm.js
+++ b/frontend/src/main/components/Earthquakes/EarthquakeForm.js
@@ -62,8 +62,8 @@ function EarthquakeForm({ initialEarthquake, submitAction, buttonLabel="Retrieve
             </Form.Group>
 
             <Button
-                type="Retrieve" //potential
-                data-testid="EarthquakeForm-Retrieve"
+                type="submit" //potential
+                data-testid="EarthquakeForm-submit"
             >
                 {buttonLabel}
             </Button>

--- a/frontend/src/main/components/Earthquakes/EarthquakeForm.js
+++ b/frontend/src/main/components/Earthquakes/EarthquakeForm.js
@@ -62,8 +62,8 @@ function EarthquakeForm({ initialEarthquake, submitAction, buttonLabel="Retrieve
             </Form.Group>
 
             <Button
-                type="submit" //potential
-                data-testid="EarthquakeForm-submit"
+                type="Retrieve" //potential
+                data-testid="EarthquakeForm-Retrieve"
             >
                 {buttonLabel}
             </Button>

--- a/frontend/src/main/components/Earthquakes/EarthquakeForm.js
+++ b/frontend/src/main/components/Earthquakes/EarthquakeForm.js
@@ -30,7 +30,7 @@ function EarthquakeForm({ initialEarthquake, submitAction, buttonLabel="Retrieve
     return (
 
         <Form onSubmit={handleSubmit(submitAction)}>
-
+            {initialEarthquake}
             <Form.Group className="mb-3" >
                 <Form.Label htmlFor="distance">Distance</Form.Label>
                 <Form.Control
@@ -49,10 +49,10 @@ function EarthquakeForm({ initialEarthquake, submitAction, buttonLabel="Retrieve
                 <Form.Label htmlFor="mag">Minimum Magnitude</Form.Label>
                 <Form.Control
                     data-testid="EarthquakeForm-mag"
-                    id="mag"
+                    id="minMag"
                     type="text"
                     isInvalid={Boolean(errors.mag)}
-                    {...register("mag", {
+                    {...register("minMag", {
                         required: "Minimum Magnitude is required."
                     })}
                 />

--- a/frontend/src/main/pages/Earthquakes/EarthquakesCreatePage.js
+++ b/frontend/src/main/pages/Earthquakes/EarthquakesCreatePage.js
@@ -13,7 +13,7 @@ export default function EarthquakesCreatePage() {
     method: "POST",
     params: {
       distance: earthquake.distance,
-      magnitude: earthquake.minMag
+      minMag: earthquake.minMag
     }
   });
 

--- a/frontend/src/main/pages/Earthquakes/EarthquakesCreatePage.js
+++ b/frontend/src/main/pages/Earthquakes/EarthquakesCreatePage.js
@@ -13,7 +13,7 @@ export default function EarthquakesCreatePage() {
     method: "POST",
     params: {
       distance: earthquake.distance,
-      magnitude: earthquake.mag
+      magnitude: earthquake.minMag
     }
   });
 

--- a/frontend/src/main/pages/Earthquakes/EarthquakesCreatePage.js
+++ b/frontend/src/main/pages/Earthquakes/EarthquakesCreatePage.js
@@ -1,14 +1,51 @@
+import React from 'react';
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import EarthquakeForm from "main/components/Earthquakes/EarthquakeForm";
+import { Navigate } from 'react-router-dom'
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
+import { useBackend } from 'main/utils/useBackend';
 
 export default function EarthquakesCreatePage() {
+
+  const objectToAxiosParams = (earthquake) => ({
+    url: "/api/earthquakes/retrieve",
+    method: "POST",
+    params: {
+      distance: earthquake.distance,
+      magnitude: earthquake.mag
+    }
+  });
+
+  const onSuccess = (earthquake) => {
+    toast(`${earthquake.length} Earthquakes retrieved`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+     { onSuccess }, 
+     // Stryker disable next-line all : hard to set up test for caching
+     ["/api/earthquakes/retrieve"]
+     );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess) {
+    return <Navigate to="/earthquakes/list" />
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Earthquakes</h1>
-        <p>
-          This is where the create page will go
-        </p>
+        <h1>Retrieve Earthquakes</h1>
+
+        <EarthquakeForm submitAction={onSubmit} />
+
       </div>
     </BasicLayout>
-  )
+  );
 }

--- a/frontend/src/main/pages/Earthquakes/EarthquakesCreatePage.js
+++ b/frontend/src/main/pages/Earthquakes/EarthquakesCreatePage.js
@@ -12,8 +12,8 @@ export default function EarthquakesCreatePage() {
     url: "/api/earthquakes/retrieve",
     method: "POST",
     params: {
-      distance: earthquake.distance,
-      minMag: earthquake.magnitude
+      distance: 10,
+      minMag: 1.2
     }
   });
 

--- a/frontend/src/main/pages/Earthquakes/EarthquakesCreatePage.js
+++ b/frontend/src/main/pages/Earthquakes/EarthquakesCreatePage.js
@@ -13,7 +13,7 @@ export default function EarthquakesCreatePage() {
     method: "POST",
     params: {
       distance: earthquake.distance,
-      minMag: earthquake.minMag
+      minMag: earthquake.magnitude
     }
   });
 

--- a/frontend/src/main/pages/Earthquakes/EarthquakesCreatePage.js
+++ b/frontend/src/main/pages/Earthquakes/EarthquakesCreatePage.js
@@ -12,8 +12,8 @@ export default function EarthquakesCreatePage() {
     url: "/api/earthquakes/retrieve",
     method: "POST",
     params: {
-      distance: 10,
-      minMag: 1.2
+      distance: earthquake.distance,
+      minMag: earthquake.minMag
     }
   });
 

--- a/frontend/src/stories/components/Earthquakes/EarthquakeForm.stories.js
+++ b/frontend/src/stories/components/Earthquakes/EarthquakeForm.stories.js
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import EarthquakeForm from "main/components/Earthquakes/EarthquakeForm"
+import { earthquakesFixtures } from 'fixtures/earthquakesFixtures';
+
+export default {
+    title: 'components/Earthquakes/EarthquakeForm',
+    component: EarthquakeForm
+};
+
+
+const Template = (args) => {
+    return (
+        <EarthquakeForm {...args} />
+    )
+};
+
+export const Default = Template.bind({});
+
+Default.args = {
+    submitText: "Create",
+    submitAction: () => { console.log("Submit was clicked"); }
+};
+
+export const Show = Template.bind({});
+
+Show.args = {
+    earthquake: earthquakesFixtures.oneEarthquake,
+    submitText: "",
+    submitAction: () => { }
+};

--- a/frontend/src/tests/components/Earthquakes/EarthquakeForm.test.js
+++ b/frontend/src/tests/components/Earthquakes/EarthquakeForm.test.js
@@ -32,9 +32,9 @@ describe("EarthquakeForm tests", () => {
                 <EarthquakeForm initialEarthquake={earthquakesFixtures.oneEarthquake} />
             </Router>
         );
-        await waitFor(() => expect(getByTestId(/EarthquakeForm-magnitude/)).toBeInTheDocument());
+        await waitFor(() => expect(getByTestId(/EarthquakeForm-mag/)).toBeInTheDocument());
         expect(getByText(/Minimum Magnitude/)).toBeInTheDocument();
-        expect(getByTestId(/EarthquakeForm-magnitude/)).toHaveValue("3.86");
+        expect(getByTestId(/EarthquakeForm-mag/)).toHaveValue("3.86");
     });
 
 /*
@@ -88,11 +88,11 @@ describe("EarthquakeForm tests", () => {
         await waitFor(() => expect(getByTestId("EarthquakeForm-distance")).toBeInTheDocument());
 
         const distanceField = getByTestId("EarthquakeForm-distance");
-        const magnitudeField = getByTestId("EarthquakeForm-magnitude");
+        const magField = getByTestId("EarthquakeForm-mag");
         const submitButton = getByTestId("EarthquakeForm-submit");
 
         fireEvent.change(distanceField, { target: { value: '1.1' } });
-        fireEvent.change(magnitudeField, { target: { value: '2.2' } });
+        fireEvent.change(magField, { target: { value: '2.2' } });
         fireEvent.click(submitButton);
 
         await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());

--- a/frontend/src/tests/components/Earthquakes/EarthquakeForm.test.js
+++ b/frontend/src/tests/components/Earthquakes/EarthquakeForm.test.js
@@ -27,9 +27,11 @@ describe("EarthquakeForm tests", () => {
 
     test("renders correctly when passing in a Earthquake ", async () => {
 
+        var eqQuery = {"distance":"3", "mag":"3.86"};
+
         const { getByText, getByTestId } = render(
             <Router  >
-                <EarthquakeForm initialEarthquake={earthquakesFixtures.oneEarthquake} />
+                <EarthquakeForm initialEarthquake={eqQuery} />
             </Router>
         );
         await waitFor(() => expect(getByTestId(/EarthquakeForm-mag/)).toBeInTheDocument());

--- a/frontend/src/tests/components/Earthquakes/EarthquakeForm.test.js
+++ b/frontend/src/tests/components/Earthquakes/EarthquakeForm.test.js
@@ -34,7 +34,7 @@ describe("EarthquakeForm tests", () => {
         );
         await waitFor(() => expect(getByTestId(/EarthquakeForm-magnitude/)).toBeInTheDocument());
         expect(getByText(/Minimum Magnitude/)).toBeInTheDocument();
-        expect(getByTestId(/EarthquakeForm-magnitude/)).toHaveValue("2.16");
+        expect(getByTestId(/EarthquakeForm-magnitude/)).toHaveValue("3.86");
     });
 
 /*

--- a/frontend/src/tests/components/Earthquakes/EarthquakeForm.test.js
+++ b/frontend/src/tests/components/Earthquakes/EarthquakeForm.test.js
@@ -27,7 +27,7 @@ describe("EarthquakeForm tests", () => {
 
     test("renders correctly when passing in a Earthquake ", async () => {
 
-        var eqQuery = {"distance":"3", "mag":"3.86"};
+        var eqQuery = {"distance":"3", "minMag":"3.86"};
 
         const { getByText, getByTestId } = render(
             <Router  >

--- a/frontend/src/tests/components/Earthquakes/EarthquakeForm.test.js
+++ b/frontend/src/tests/components/Earthquakes/EarthquakeForm.test.js
@@ -1,0 +1,121 @@
+import { render, waitFor, fireEvent } from "@testing-library/react";
+import EarthquakeForm from "main/components/Earthquakes/EarthquakeForm";
+import { earthquakesFixtures } from "fixtures/earthquakesFixtures";
+import { BrowserRouter as Router } from "react-router-dom";
+
+const mockedNavigate = jest.fn();
+
+jest.mock('react-router-dom', () => ({
+    ...jest.requireActual('react-router-dom'),
+    useNavigate: () => mockedNavigate
+}));
+
+
+describe("EarthquakeForm tests", () => {
+
+    test("renders correctly ", async () => {
+
+        const { getByText } = render(
+            <Router  >
+                <EarthquakeForm />
+            </Router>
+        );
+        await waitFor(() => expect(getByText(/Distance/)).toBeInTheDocument());
+        await waitFor(() => expect(getByText(/Retrieve/)).toBeInTheDocument());
+    });
+
+
+    test("renders correctly when passing in a Earthquake ", async () => {
+
+        const { getByText, getByTestId } = render(
+            <Router  >
+                <EarthquakeForm initialEarthquake={earthquakesFixtures.oneEarthquake} />
+            </Router>
+        );
+        await waitFor(() => expect(getByTestId(/EarthquakeForm-magnitude/)).toBeInTheDocument());
+        expect(getByText(/Minimum Magnitude/)).toBeInTheDocument();
+        expect(getByTestId(/EarthquakeForm-magnitude/)).toHaveValue("2.16");
+    });
+
+/*
+    test("Correct Error messsages on bad input", async () => {
+
+        const { getByTestId, getByText } = render(
+            <Router  >
+                <UCSBDateForm />
+            </Router>
+        );
+        await waitFor(() => expect(getByTestId("UCSBDateForm-quarterYYYYQ")).toBeInTheDocument());
+        const quarterYYYYQField = getByTestId("UCSBDateForm-quarterYYYYQ");
+        const localDateTimeField = getByTestId("UCSBDateForm-localDateTime");
+        const submitButton = getByTestId("UCSBDateForm-submit");
+
+        fireEvent.change(quarterYYYYQField, { target: { value: 'bad-input' } });
+        fireEvent.change(localDateTimeField, { target: { value: 'bad-input' } });
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(getByText(/QuarterYYYYQ must be in the format YYYYQ/)).toBeInTheDocument());
+        expect(getByText(/localDateTime must be in ISO format/)).toBeInTheDocument();
+    });
+*/
+    test("Correct Error messsages on missing input", async () => {
+
+        const { getByTestId, getByText } = render(
+            <Router  >
+                <EarthquakeForm />
+            </Router>
+        );
+        await waitFor(() => expect(getByTestId("EarthquakeForm-submit")).toBeInTheDocument());
+        const submitButton = getByTestId("EarthquakeForm-submit");
+
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(getByText(/Distance is required./)).toBeInTheDocument());
+        expect(getByText(/Minimum Magnitude is required./)).toBeInTheDocument();
+
+    });
+
+    test("No Error messsages on good input", async () => {
+
+        const mockSubmitAction = jest.fn();
+
+
+        const { getByTestId, queryByText } = render(
+            <Router  >
+                <EarthquakeForm submitAction={mockSubmitAction} />
+            </Router>
+        );
+        await waitFor(() => expect(getByTestId("EarthquakeForm-distance")).toBeInTheDocument());
+
+        const distanceField = getByTestId("EarthquakeForm-distance");
+        const magnitudeField = getByTestId("EarthquakeForm-magnitude");
+        const submitButton = getByTestId("EarthquakeForm-submit");
+
+        fireEvent.change(distanceField, { target: { value: '1.1' } });
+        fireEvent.change(magnitudeField, { target: { value: '2.2' } });
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());
+
+    });
+
+
+    test("Test that navigate(-1) is called when Cancel is clicked", async () => {
+
+        const { getByTestId } = render(
+            <Router  >
+                <EarthquakeForm />
+            </Router>
+        );
+        await waitFor(() => expect(getByTestId("EarthquakeForm-cancel")).toBeInTheDocument());
+        const cancelButton = getByTestId("EarthquakeForm-cancel");
+
+        fireEvent.click(cancelButton);
+
+        await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith(-1));
+
+    });
+
+});
+
+

--- a/frontend/src/tests/pages/Earthquakes/EarthquakesCreatePage.test.js
+++ b/frontend/src/tests/pages/Earthquakes/EarthquakesCreatePage.test.js
@@ -102,7 +102,7 @@ describe("EarthquakesCreatePage tests", () => {
         expect(axiosMock.history.post[0].params).toEqual(
             {
             "distance": "12",
-            "magnitude": "0.9",
+            "minMag": "0.9",
         });
 
 

--- a/frontend/src/tests/pages/Earthquakes/EarthquakesCreatePage.test.js
+++ b/frontend/src/tests/pages/Earthquakes/EarthquakesCreatePage.test.js
@@ -1,22 +1,46 @@
-import { render } from "@testing-library/react";
+import { render, waitFor, fireEvent } from "@testing-library/react";
 import EarthquakesCreatePage from "main/pages/Earthquakes/EarthquakesCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-
-import { apiCurrentUserFixtures }  from "fixtures/currentUserFixtures";
+import { earthquakesFixtures } from "fixtures/earthquakesFixtures";
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
 
 describe("EarthquakesCreatePage tests", () => {
 
     const axiosMock =new AxiosMockAdapter(axios);
-    axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
-    axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
 
-    const queryClient = new QueryClient();
+    beforeEach(() => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    });
+
     test("renders without crashing", () => {
+        const queryClient = new QueryClient();
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
@@ -26,6 +50,65 @@ describe("EarthquakesCreatePage tests", () => {
         );
     });
 
+    test("renders oneEarthquake for regular user without crashing", () => {
+        const queryClient = new QueryClient();
+        axiosMock.onGet("/api/earthquakes/retrieve").reply(200, earthquakesFixtures.oneEarthquake);
+
+        const {getByTestId} = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <EarthquakesCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+    test("when you fill in the form and hit submit, it makes a request to the backend", async () => {
+
+        const queryClient = new QueryClient();
+        const earthquake = {
+            distance: 12,
+            mag: 0.9,
+            length: 1
+        };
+
+        axiosMock.onPost("/api/earthquakes/retrieve").reply(202, earthquake);
+
+        const { getByTestId } = render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <EarthquakesCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(getByTestId("EarthquakeForm-distance")).toBeInTheDocument();
+        });
+
+        const distanceField = getByTestId("EarthquakeForm-distance");
+        const magnitudeField = getByTestId("EarthquakeForm-mag");
+        const submitButton = getByTestId("EarthquakeForm-submit");
+
+        fireEvent.change(distanceField, { target: { value: '12' } });
+        fireEvent.change(magnitudeField, { target: { value: '0.9' } });
+
+        expect(submitButton).toBeInTheDocument();
+
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+        expect(axiosMock.history.post[0].params).toEqual(
+            {
+            "distance": "12",
+            "magnitude": "0.9",
+        });
+
+
+        expect(mockToast).toBeCalledWith("1 Earthquakes retrieved");
+        expect(mockNavigate).toBeCalledWith({ "to": "/earthquakes/list" });
+    });
+
+
 });
-
-

--- a/frontend/src/tests/pages/Earthquakes/EarthquakesCreatePage.test.js
+++ b/frontend/src/tests/pages/Earthquakes/EarthquakesCreatePage.test.js
@@ -68,7 +68,7 @@ describe("EarthquakesCreatePage tests", () => {
         const queryClient = new QueryClient();
         const earthquake = {
             distance: 12,
-            mag: 0.9,
+            minMag: 0.9,
             length: 1
         };
 

--- a/frontend/src/tests/pages/Earthquakes/EarthquakesCreatePage.test.js
+++ b/frontend/src/tests/pages/Earthquakes/EarthquakesCreatePage.test.js
@@ -68,7 +68,7 @@ describe("EarthquakesCreatePage tests", () => {
         const queryClient = new QueryClient();
         const earthquake = {
             distance: 12,
-            minMag: 0.9,
+            magnitude: 0.9,
             length: 1
         };
 

--- a/src/main/java/edu/ucsb/cs156/example/controllers/EarthquakesController.java
+++ b/src/main/java/edu/ucsb/cs156/example/controllers/EarthquakesController.java
@@ -59,7 +59,7 @@ public class EarthquakesController extends ApiController {
             ) throws JsonProcessingException {
         log.info("getEarthquakes: distance={} minMag={}", distance, minMag);
         
-        String json = earthquakeQueryService.getJSON(distance, minMag); 
+        String json = earthquakeQueryService.getJSON(distance, minMag);
         //json returned from Earthquakes API returns a FeatureCollection object
         FeatureCollection featureCollection = mapper.readValue(json, FeatureCollection.class);	
         


### PR DESCRIPTION
# Overview

Implemented the Retrieve Form and Retrieve page. Correctly calls the retrieve endpoint.

![image](https://user-images.githubusercontent.com/56047961/156029931-30c6b2f6-a8a8-4427-9776-6a74da5a0c6c.png)

![image](https://user-images.githubusercontent.com/56047961/156029950-58fb8c43-beb9-4585-b222-ebb74e39197d.png)

100% on npx stryker and npm coverage